### PR TITLE
2025.01.27 DP - 겹치지 않게 선분 고르기 2

### DIFF
--- a/Codetree_Practice/2025-01/PickLine.java
+++ b/Codetree_Practice/2025-01/PickLine.java
@@ -1,0 +1,58 @@
+import java.io.*;
+import java.util.*;
+import java.lang.*;
+
+class Line implements Comparable<Line>{
+    int start;
+    int end;
+
+    public Line(int start, int end){
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public int compareTo(Line l){
+        return this.start - l.start;
+    }
+}
+
+public class PickLine {
+    static int n;
+    static Line[] lines;
+    static int[] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        lines = new Line[n];
+        dp = new int[n];
+
+        for(int i = 0; i<n; i++){
+            st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            lines[i] = new Line(start, end);
+        }
+
+        Arrays.sort(lines, 0, n);
+
+        for(int i = 0; i<n; i++){
+            dp[i] = 1;
+
+            for(int j = 0; j<i; j++){
+                if(lines[j].end < lines[i].start) dp[i] = Math.max(dp[i], dp[j]+1);
+            }
+        }
+
+        int ans = 0;
+
+        for(int i = 0; i<n; i++){
+            ans = Math.max(ans, dp[i]);
+        }
+
+        System.out.print(ans);
+    }
+}


### PR DESCRIPTION
- DP 어렵다... DP 어렵다... DP 어렵다...
- 일직선 상에 놓인 선분들을 주고, 겹치지 않게 고를 수 있는 최대 개수를 구하는건데... 시작점을 오름차순으로 정렬해야 할 것이란건 짐작하고 있었으나 Comparable 인터페이스를 구현하고... compartTo 메서드를 오버라이드해서 정렬 구현하는것은 아직도 익숙해지지 못했다.
- 그렇게 오름차순 정렬한 후에, dp[i]를 "i번째 선분까지 고르면서 가능했던 최대 개수"로 상정한 후에 조건(선분이 겹치지 않는지)을 따져서 dp[i]를 구하면 되는건데... dp 문제를 많이 풀었다고 생각했지만 아직 저런 사고에 익숙하지 않은 것 같다.............