### PR TITLE
2025.02.19 - DP 최대 합 분할

### DIFF
--- a/Codetree_Practice/2025-02/MaxSumDivision.java
+++ b/Codetree_Practice/2025-02/MaxSumDivision.java
@@ -1,0 +1,62 @@
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    static int n;
+    static int m;
+    static int[] arr;
+    static int[][] dp;
+    final static int offset = 100000;
+
+    public static void init(){
+        for(int i = 0; i<n; i++){
+            for(int j = -m; j<m; j++){
+                dp[i][j+offset] = Integer.MIN_VALUE;
+            }
+        }
+        dp[0][0+offset] = 0;
+    }
+
+    public static void update(int i, int j, int prevI, int prevJ, int val){
+        if(prevJ<-m || prevJ>m || dp[prevI][prevJ+offset] == Integer.MIN_VALUE) return ;
+        dp[i][j+offset] = Math.max(dp[i][j+offset], dp[prevI][prevJ+offset]+val);
+    }
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        n = Integer.parseInt(br.readLine());
+        m = 0;
+
+        arr = new int[n+1];
+        st = new StringTokenizer(br.readLine());
+        for(int i = 1; i<=n; i++){
+            arr[i] = Integer.parseInt(st.nextToken());
+            m += arr[i];
+        }
+
+        // dp[i][j] : i번째 수 까지 고려했을 때 A의 합과 B의 합의 차이가 j일 때의 A의 최대 합
+        dp = new int[n+1][m+1+offset];
+
+        init();
+
+        for(int i = 1; i<=n; i++){
+            for(int j = -m; j<=m; j++){
+                // Case 1. 그룹 A에 i번째 원소를 추가하여 그룹A-그룹B가 j가 된 경우
+                // dp[i - 1][j - arr[i]] + arr[i] -> dp[i][j]
+                update(i, j, i - 1, j - arr[i], arr[i]);
+
+                // Case 2. 그룹 B에 i번째 원소를 추가하여 그룹A-그룹B가 j가 된 경우
+                // dp[i - 1][j + arr[i]] -> dp[i][j]
+                update(i, j, i - 1, j + arr[i], 0);
+
+                // Case 3. 그룹 C에 i번째 원소를 추가하여 그룹A-그룹B가 j가 된 경우
+                // dp[i - 1][j] -> dp[i][j]
+                update(i, j, i  - 1, j, 0);
+            }
+        }
+
+        System.out.print(dp[n][0+offset]);
+
+    }
+}


### PR DESCRIPTION
- DP는 나름 마스터 했다고 생각했는데, 큰 오산이었음
- 문제 내용 : 숫자들을 A그룹과 B그룹과 C그룹에 나눠서 넣음. A그룹 숫자의 합과 B그룹 숫자의 합이 같을 때 합이 가장 큰 경우를 구하기
- dp의 정의를 세우는 것 부터 못해서 못풀고 해설을 봤음. 근데 해설을 보니까 더 이해가 어려워지는 것이었습니다?
- dp[i][j] : i번째 숫자까지 고려했을 때 A그룹과 B그룹의 차가 j인 경우 A의 최대 합
- i번째 숫자가 A그룹에 들어가는 경우, B그룹에 들어가는 경우, C그룹에 들어가는 경우로 나눠서 생각을 해야한다는 발상도 못했음
- 그리고 그렇게 경우를 나눠주면서 dp 배열 범위를 넘어가는 문제를 방지하려고 offset을 두는 개념도 생소했음
- 내일 다시 보고 다시 풀것임...