### PR TITLE
2025.02.27 - DP : 올바른 등식 만들기

### DIFF
--- a/RightEquation.java
+++ b/RightEquation.java
@@ -1,0 +1,35 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    final static int offset = 20;
+    static int n;
+    static int m;
+    static int[] num;
+    static long[][] dp; // dp[i][j] : 숫자를 i개 고려했을 때 합이 j인 경우의 개수
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        num = new int[n+1];
+        dp = new long[n+1][2*offset+1];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 1; i<=n; i++){
+            num[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dp[0][0+offset] = 1;
+
+        for(int i = 1; i<=n; i++){
+            for(int j = -1*offset; j<=offset; j++){
+                if(j+num[i]<=20) dp[i][j+num[i]+offset] += dp[i-1][j+offset];
+                if(j-num[i]>=-20) dp[i][j-num[i]+offset] += dp[i-1][j+offset];
+            }
+        }
+
+        System.out.print(dp[n][m+offset]);
+    }
+}


### PR DESCRIPTION
- dp[i][j] : 숫자를 i개 고려했을 때 합이 j인 경우의 개수
- 합이 음수인 경우도 고려를 해줘야 해서, offset을 활용해서 dp 테이블을 채웠음. 합의 가능 범위가 -20 ~ +20 이었기 때문에 offset은 20으로 설정해서 계산함
- offset 사용하는 것에 나름 적응을 한 것 같아서 기뻤음
- 그리고 오랜만에 해설의 힌트를 보지 않고 풀어서, 더욱 기뻤음